### PR TITLE
Fix typos in the OsmAnd 2.3 release announcement

### DIFF
--- a/website/blog_articles/osmand-2-3-released.html
+++ b/website/blog_articles/osmand-2-3-released.html
@@ -2,14 +2,14 @@
 <div class="date">March 6, 2016</div>
 <p>OsmAnd 2.3 is on its way! Get ready for a brand new route preparation interface, improved UI, and more. We also added a revolutionary feature for you to try. Read on to find out about all the new things in 2.3 version and hurry to update it!</p>
 <h4>OSM Live</h4>
-<p>The most important and outstanding feature of the new release is OSM Live. It's the system that will encourage OSM mappers to update the information and will give you frequent updates (up to once an hour). You make a donation and receive the updates, 30% goes to OsmAnd team and 70% is spread between OSM contributors who have registered in OSM Live program. They are encouraged to make more updates and you get fresh and more detailed maps. Please read more and join <a href="http://osmand.net/osm_live#information">here</a>.</p>
+<p>The most important and outstanding feature of the new release is OSM Live. It's the system that will encourage OSM mappers to update the information and will give you frequent updates (up to once an hour). You make a donation and receive the updates, 30% goes to the OsmAnd team and 70% is spread between OSM contributors who have registered in the OSM Live program. They are encouraged to make more updates and you get fresh and more detailed maps. Please read more and join <a href="http://osmand.net/osm_live#information">here</a>.</p>
 <div class="centeredimageblog">
 <img src="images/blog/2.3/ver_2_3_1.jpg"/>
 <img src="images/blog/2.3/ver_2_3_2.jpg"/>
 <div style="clear:both;"></div>
 </div>
 <h4>New map markers interface</h4>
-<p>We've introduced a completely new way of managing your trip &mdash; the map markers function. Map markers are similar to waypoints, but they are much more convenient. You can choose to add a point to the route as last intermediate point, destination, etc. immediately, arrange waypoints in seconds (just press the icon in the right upper corner of the screen), see favorites, POI, and traffic warnings, choose which you need and delete the rest. For example, you created a route and want to see the some fun places on your way. You turn on the Leisure category of POI and delete the points you do not need, leaving only the main ones.</p>
+<p>We've introduced a completely new way of managing your trip &mdash; the map markers function. Map markers are similar to waypoints, but they are much more convenient. You can choose to add a point to the route as last intermediate point, destination, etc. immediately, arrange waypoints in seconds (just press the icon in the right upper corner of the screen), see favorites, POI, and traffic warnings, choose which you need and delete the rest. For example, you created a route and want to see some fun places on your way. You turn on the Leisure category of POI and delete the points you do not need, leaving only the main ones.</p>
 <div class="centeredimageblog">
 <img src="images/blog/2.3/ver_2_3_4.jpg"/>
 <img src="images/blog/2.3/ver_2_3_6.jpg"/>
@@ -26,4 +26,4 @@
 <img src="images/blog/2.3/ver_2_3_3.jpg"/>
 <div style="clear:both;"></div>
 </div>
-<p>Other improvements: we've added a menu item Builds. This section will let you download not only an OsmAnd version of your choice but also a particular build if you need to test features or go back to the older version. Besides that, text rendering throughout the application has become better.</p>
+<p>Other improvements: we've added a Builds menu item. This section will let you download not only an OsmAnd version of your choice but also a particular build if you need to test features or go back to the older version. Besides that, text rendering throughout the application has become better.</p>


### PR DESCRIPTION
The first two changes are unclear in the Github diff viewer.

The first change replaces "OsmAnd team" with "the OsmAnd team" and "OSM Live program" with "the OSM Live program".

The second change fixes a typo: "want to see *the* some fun places". I've removed the incorrect "the".