### PR TITLE
Add missing slash after https://osmand.net in rss.xml

### DIFF
--- a/website/templates/pub/rss.xml
+++ b/website/templates/pub/rss.xml
@@ -8,8 +8,8 @@
 		<generator></generator>
 		<item th:each="art : ${articles}">
 			<title th:text="${art.title}"></title>
-			<link th:text="${'https://osmand.net'+art.url}"></link>
-			<guid isPermaLink="true" th:text="${'https://osmand.net'+art.url}"></guid>
+			<link th:text="${'https://osmand.net/'+art.url}"></link>
+			<guid isPermaLink="true" th:text="${'https://osmand.net/'+art.url}"></guid>
 			<description th:utext="${'<![CDATA['+art.content+']]>'}"></description>
 			<pubDate th:text="${art.dateRSS}"></pubDate>
 		</item>


### PR DESCRIPTION
Hi @somini @vshcherb, here is a simple fix for your page rss.xml
Slashes are missing after website url "https://osmand.net" in `<link>` and `<guid>`
The resulting url "https://osmand.netblog" are not working.
![image](https://user-images.githubusercontent.com/6597721/48373253-95235f00-e6c1-11e8-8b8a-061d201f862b.png)

BTW, I test on Mozilla Firefox 63.0.1 (64 bits)