### PR TITLE
Added Lantmäteriet Topo (SE) in tile_sources.xml

### DIFF
--- a/website/tile_sources.xml
+++ b/website/tile_sources.xml
@@ -123,6 +123,8 @@
   
 
   <tile_source name="Hitta.se Outdoor (SE)" rule="beanshell" ext="png" min_zoom="5" max_zoom="18" tile_size="256" img_density="32" avg_img_size="18000" url_template='String getTileUrl(int z, int x, int y) {return "http://static.hitta.se/tile/v3/4/"+z+"/"+x+"/"+((1 &lt;&lt; z) - 1 - y);}'/>
+  <tile_source name="Lantmäteriet Topo (SE)" rule="beanshell" ext="png" min_zoom="3" max_zoom="15" tile_size="256" img_density="32" avg_img_size="18000" url_template='https://api.lantmateriet.se/open/topowebb-ccby/v1/wmts/token/9b342b7d9f12d4ddb92277be9869d860/1.0.0/topowebb/default/3857/{0}/{2}/{1}.png'/>
+
 <!--
 	// WMS layers : http://whoots.mapwarper.net/tms/{$z}/{$x}/{$y}/ {layer}/{Path}
 	// 1. Landsat http://onearth.jpl.nasa.gov/wms.cgi global_mosaic (NOT WORK)


### PR DESCRIPTION
This adds a Topo-map from the Swedish National Land Survey - Lantmäteriet.

The api-key comes from the opensteetmap editor.

The map requires attribution... But I guess that is implied when you select your source.