### PR TITLE
Improve german discount message

### DIFF
--- a/website/api/messages/motd_config.json
+++ b/website/api/messages/motd_config.json
@@ -192,7 +192,7 @@
 			},
 			"file": "discount.json",
 			"fields": {
-				"message": "VERKAUF!",
+				"message": "SALE!",
 				"description": "Unbegrenzte Karten-Downloads, Höhenlinien und Jahresabonnement -50%!"
 			}
 		},
@@ -286,7 +286,7 @@
 			},
 			"file": "discount_ios_sub.json",
 			"fields": {
-				"message": "AUSVERKAUF!",
+				"message": "SALE!",
 				"description": "Alle Weltkarten, Höhenlinien und Jahresabonnement -50%!"
 			}
 		},


### PR DESCRIPTION
"Verkauf" or "Ausverkauf" is technically correct, but not used in daily life in german-speaking countries. The anglicism "sale" is used throughout - as is even stated in https://de.wikipedia.org/wiki/Saisonschlussverkauf (right at end of introduction chapter).