### PR TITLE
Add OSM Public Tracks overlay to tile_sources.xml

### DIFF
--- a/website/tile_sources.xml
+++ b/website/tile_sources.xml
@@ -101,6 +101,7 @@
   <tile_source name="Geofabrik.highways_eu" url_template="https://tools.geofabrik.de/osmi/tiles/highways/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="16" tile_size="256" img_density="16" avg_img_size="18000" />
 
   <tile_source name="OSM FR" url_template="https://a.tile.openstreetmap.fr/osmfr/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="20" tile_size="256" img_density="16" avg_img_size="18000"/>
+  <tile_source name="OSM Public Tracks" url_template="https://gps.tile.openstreetmap.org/lines/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="20" tile_size="256" img_density="16" avg_img_size="11000"/>
   
   <tile_source name="OpenTopoMap" url_template="https://a.tile.opentopomap.org/{0}/{1}/{2}.png" ext=".png" min_zoom="1" max_zoom="15" tile_size="256" img_density="16" avg_img_size="56000"/>
 


### PR DESCRIPTION
This PR adds an OSM overlay for user-submitted tracks to the `tile_sources.xml`.
Example tile: https://gps.tile.openstreetmap.org/lines/13/4725/2636.png