### PR TITLE
Add Finnish MML maps provided by Kapsi to tile_sources.xml

### DIFF
--- a/website/tile_sources.xml
+++ b/website/tile_sources.xml
@@ -145,6 +145,12 @@
    <!-- http://kelkkareitit.fi -->
    <tile_source name="Kelkkareitit.fi (snowmobile overlay)" url_template="https://tiles.kelkkareitit.fi/kelkkareitit/{0}/{1}/{2}.png" ext=".png" min_zoom="3" max_zoom="18" tile_size="256" img_density="8" avg_img_size="10000"/>
 
+   <!-- https://kartat.kapsi.fi/ (c) Maanmittauslaitos CC BY 4.0 -->
+   <tile_source name="MML Peruskartta (FI)" url_template="https://tiles.kartat.kapsi.fi/peruskartta/{0}/{1}/{2}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="8" avg_img_size="10000"/>
+   <tile_source name="MML Taustakartta (FI)" url_template="https://tiles.kartat.kapsi.fi/taustakartta/{0}/{1}/{2}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="8" avg_img_size="10000"/>
+   <tile_source name="MML Ortoilmakuva (FI)" url_template="https://tiles.kartat.kapsi.fi/ortokuva/{0}/{1}/{2}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="8" avg_img_size="10000"/>
+   <tile_source name="MML Kiinteistörajat (FI)" url_template="https://tiles.kartat.kapsi.fi/kiinteistorajat/{0}/{1}/{2}.jpg" ext=".jpg" min_zoom="1" max_zoom="19" tile_size="256" img_density="8" avg_img_size="10000"/>
+	
    <tile_source name="GeoVelo" url_template="https://tiles4.geovelo.fr/raster/facilities/{0}/{1}/{2}.png" ext=".png" min_zoom="2" max_zoom="16" tile_size="256" img_density="8" avg_img_size="10000"/>
 
 


### PR DESCRIPTION
This commit adds four different MML maps of Finland to tile_sources.xml.

MML (Maanmittauslaitos / National Land Survey of Finland) provides multiple high quality maps of Finland as open data. Kapsi is a nonprofit organization that provides a tile server for the open map data.

Finnish info on the MML license and the service provided by Kapsi is available at https://kartat.kapsi.fi/
The data is licensed as Creative Commons Attribution 4.0 International: https://www.maanmittauslaitos.fi/en/opendata-licence-cc40

I don't know how to determine tile_size, img_density or avg_img_size, I've copied them from another entry and they should be checked.
Supported zoom levels are guessed from the data the server returns.