### PR TITLE
add tile source for OpenFlightMaps

### DIFF
--- a/website/tile_sources.xml
+++ b/website/tile_sources.xml
@@ -153,5 +153,8 @@
 	
    <tile_source name="GeoVelo" url_template="https://tiles4.geovelo.fr/raster/facilities/{0}/{1}/{2}.png" ext=".png" min_zoom="2" max_zoom="16" tile_size="256" img_density="8" avg_img_size="10000"/>
 
+   <!-- https://www.openflightmaps.org/ -->
+  <tile_source name="OpenFlightMaps" url_template="https://nwy-tiles-api.prod.newaydata.com/tiles/{z}/{x}/{y}.png?path=latest/aero/latest" ext=".png" min_zoom="7" max_zoom="12" tile_size="512" img_density="32" avg_img_size="150000"/>
+
 
 </tile_sources>


### PR DESCRIPTION
This changes adds the tile source for [OpenFlightMaps](https://www.openflightmaps.org/), which enables the display of aeronautical maps.

Thanks for considering.

refs osmandapp/OsmAnd#6510

I am unsure what `img_density` actually is, so feel free to question this value.