### PR TITLE
Fix logo-grey link in gocontainer

### DIFF
--- a/website/css/site.css
+++ b/website/css/site.css
@@ -2894,7 +2894,7 @@ a,a:visited
 .gocontainer .popup .logo
 {
 	height:50px;
-	background:url("images/logo-grey.png") no-repeat;
+	background:url("/images/logo-grey.png") no-repeat;
 	background-size:contain;
 	background-position:center;
 	margin-bottom:5%;


### PR DESCRIPTION
Steps to replicate the problem:

1. go to e.g. https://osmand.net/go.html?lat=0&lon=0 using an iOS device in portrait mode
2. observe the top section of the popup
3. expected: OsmAnd logo appears
  observed: blank space

