### PR TITLE
Add Android equivalent for iOS app popup

### DIFF
--- a/website/go.html
+++ b/website/go.html
@@ -52,12 +52,20 @@
       </div>
   </div>
   <div class="overlay" style="display:none;"></div>
-  <div class="popup" style="display:none;">
+  <div class="popup ios-popup" style="display:none;">
   <div class="logo"></div>
   <h1>Did you know</h1>
   <p>OsmAnd has an iOS application</p>
   <a class="button yes" href="javascript:void(0);">Yep, I've already got it</a>
   <a class="button no" href="javascript::void(0);">Nope, but I'd love to try it</a>
+  <a class="button cancel" href="javascript:void(0);">Leave me alone</a>
+  </div>
+  <div class="popup android-popup" style="display:none;">
+  <div class="logo"></div>
+  <h1>OsmAnd Web Viewer</h1>
+  <p>View location in your app instead?</p>
+  <a class="button yes" href="javascript::void(0);">Yes, I've got a maps app</a>
+  <a class="button no" href="javascript:void(0);">No, I'd like to try OsmAnd's app</a>
   <a class="button cancel" href="javascript:void(0);">Leave me alone</a>
   </div>
 </div>


### PR DESCRIPTION
When you use `osmand.net/go` links on an iOS device, a popup asks whether you'd prefer to use OsmAnd's app instead.

This patch adds equivalent functionality for Android users.  It uses `geo:` URIs and has slightly different text, because most Android visitors will have Google Maps installed.