### PR TITLE
Fix a caching issue with #191

### DIFF
--- a/website/css/site.css
+++ b/website/css/site.css
@@ -3321,3 +3321,7 @@ a,a:visited
     top: 124px;
   }
 }
+/*
+ * See our GitHub repository at https://github.com/osmandapp/osmandapp.github.io
+ * If you edit this file, also increment the "go.css?v=" parameters throughout the project
+ */

--- a/website/go.html
+++ b/website/go.html
@@ -9,7 +9,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OsmAnd - Offline Mobile Maps and Navigation</title>
-  <link rel="stylesheet" type="text/css" href="/css/site.css?v=4"/>
+  <link rel="stylesheet" type="text/css" href="/css/site.css?v=5"/>
 <!--  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" /> -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet.js"></script>
@@ -19,7 +19,7 @@
 -->	
 
   <script type="text/javascript" src="/scripts/js.cookie.js"></script>
-  <script type="text/javascript" src="/scripts/go.js?v=5"></script>
+  <script type="text/javascript" src="/scripts/go.js?v=6"></script>
 </head>
 <body>
   <div class="gocontainer" id="gocontainer">

--- a/website/scripts/go.js
+++ b/website/scripts/go.js
@@ -322,3 +322,7 @@ var androidAppRedirect = {
 	iosAppRedirect.init();
 	androidAppRedirect.init();
   });
+/*
+ * See our GitHub repository at https://github.com/osmandapp/osmandapp.github.io
+ * If you edit this file, also increment the "go.js?v=" parameter in ../go.html
+ */

--- a/website/templates/pub/fragments/default_links.html
+++ b/website/templates/pub/fragments/default_links.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<link rel="stylesheet" type="text/css" href="/css/site.css?v=20"/>
+<link rel="stylesheet" type="text/css" href="/css/site.css?v=21"/>
 <script type="text/javascript" src="/scripts/jquery-3.1.0.min.js"></script>
 <link rel="apple-touch-icon" sizes="180x180" href="/images/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" href="/images/favicons/favicon-32x32.png" sizes="32x32">


### PR DESCRIPTION
#191 (also from me) isn't showing up in browsers that have previously cached `scripts/go.js`.

This PR does the following:

First, increments all `?v=` numbers for affected files (e.g. `?v=4` -> `?v=5`).  `git grep site.css` shows some other links that don't have a `?v=` parameter to increment - I haven't updated them because it might be correct behaviour for all I know.  Otherwise, you might have an unrelated bug.

Second, adds a reminder to `go.js` and `site.css`, so the next person knows to increment these values at the same time.

Finally, adds a link to this repo from `go.js` and `site.css`.  It took me a while to find the repo last time, and the distraction of searching is probably among the reasons I didn't notice this issue back then.  So I'd argue this counts as a fix for the same bug, but I'm happy to remove it or put it in a separate PR if you'd prefer.